### PR TITLE
adding a backoff time to retries

### DIFF
--- a/src/main/java/com/slickqa/client/impl/ApiPart.java
+++ b/src/main/java/com/slickqa/client/impl/ApiPart.java
@@ -73,6 +73,12 @@ public class ApiPart<T> implements RetrieveUpdateDeleteApi<T>, QueryAndCreateApi
                     return null;
                 }
             }
+            try {
+                if(i < 2) {
+                    Thread.sleep((i + 1) * 1000);
+                }
+            } catch(Exception e) {
+            }
         }
         if(lastException != null)
             throw new SlickCommunicationError(target.getUri().toString(), lastResponse, lastException);
@@ -110,6 +116,12 @@ public class ApiPart<T> implements RetrieveUpdateDeleteApi<T>, QueryAndCreateApi
                 } else {
                     return null;
                 }
+            }
+            try {
+                if(i < 2) {
+                    Thread.sleep((i + 1) * 1000);
+                }
+            } catch(Exception e) {
             }
         }
         if(lastException != null)

--- a/src/main/java/com/slickqa/client/impl/FilesApiPart.java
+++ b/src/main/java/com/slickqa/client/impl/FilesApiPart.java
@@ -108,6 +108,12 @@ public class FilesApiPart extends ApiPart<StoredFile> implements FilesQueryApi, 
                     lastException = e;
                 }
             }
+            try {
+                if(i < 2) {
+                    Thread.sleep((i + 1) * 1000);
+                }
+            } catch(Exception e) {
+            }
         }
         if(lastException != null)
             throw new SlickCommunicationError(target.getUri().toString(), lastResponse, lastException);


### PR DESCRIPTION
Currently if we have to retry we do so instantly.  this adds a few seconds of backoff time in case of an error.